### PR TITLE
Edited Ignitiond daemon name and directory to be more standard

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -176,13 +176,13 @@ ifeq (${USE_WALLET}, 1)
         obj/walletdb.o
 endif
 
-all: Ignitiond
+all: ignitiond
 
 # build secp256k1
 DEFS += $(addprefix -I,$(CURDIR)/secp256k1/include)
 secp256k1/src/libsecp256k1_la-secp256k1.o:
 	@echo "Building Secp256k1 ..."; cd secp256k1; chmod 755 *; ./autogen.sh; ./configure --enable-module-recovery; make; cd ..;
-Ignitiond: secp256k1/src/libsecp256k1_la-secp256k1.o
+ignitiond: secp256k1/src/libsecp256k1_la-secp256k1.o
 
 # build leveldb
 LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
@@ -210,11 +210,11 @@ obj/%.o: %.c
 	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
 	  rm -f $(@:%.o=%.d)
 
-Ignitiond: $(OBJS:obj/%=obj/%)
-	$(LINK) $(xCXXFLAGS) -o $@ $^ $(xLDFLAGS) $(LIBS)
+ignitiond: $(OBJS:obj/%=obj/%)
+	$(LINK) $(xCXXFLAGS) -o ../bin/$@ $^ $(xLDFLAGS) $(LIBS)
 
 clean:
-	-rm -f Ignitiond
+	-rm -f ignitiond
 	-rm -f obj/*.o
 	-rm -f obj/*.P
 	-rm -f obj/build.h


### PR DESCRIPTION
We may in the future want to move the daemon into a system level folder for unix, win, osx and other supported operating systems like bitcoin does it. For now the daemon will reside in a dedicated binaries folder for clarity.

NOTE: May need to update the instructions to run daemon if necessary readmes