### PR TITLE
Fixed HelpMessage() duplicating the help text. 

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -301,7 +301,7 @@ strUsage += "\n" + _("Masternode options:") + "\n";
     strUsage += _("Secure messaging options:") + "\n" +
         "  -nosmsg                                  " + _("Disable secure messaging.") + "\n" +
         "  -debugsmsg                               " + _("Log extra debug messages.") + "\n" +
-        "  -smsgscanchain                           " + _("Scan the block chain for public key addresses on startup.") + "\n" +
+        "  -smsgscanchain                           " + _("Scan the block chain for public key addresses on startup.") + "\n";
     strUsage += "  -stakethreshold=<n> " + _("This will set the output size of your stakes to never be below this number (default: 100)") + "\n";
 
     return strUsage;


### PR DESCRIPTION
added a semicolon after ending of secure messaging options instead of a plus sign.

Varible strusage was getting added to itself when it shouldnt have.