### PR TITLE
Update the gitignore to ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ compile-blk.sh
 .DS_Store
 Ignition.pro
 Ignitiond
+Ignition-qt
+qrc_bitcoin\.cpp
+build/
+*.qm


### PR DESCRIPTION
A small change to the gitignore file to ignore the generated files:
- Ignition-qt: main executable
- qrc_bitcoin.cpp: QT resource file
- build/: folder containing all the build result
- *.qm: QT generated locale files