### PR TITLE
Fix for issue #9: wallet not staking after unlocking

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1963,11 +1963,11 @@ Value walletpassphrase(const Array& params, bool fHelp)
     pwalletMain->TopUpKeyPool();
 
     int64_t nSleepTime = params[1].get_int64();
-    // Timeout limits:
-    // If the timeout is larger than the max value of int64 (922337203685477580), nSleepTime will be negative
-    // If the timeout is larger than 999999000000000, boost will not be able to convert it to seconds
-    if (nSleepTime < 0 || nSleepTime > 999999000000000)
+    // If the timeout value is too large, the conversion from nSleepTime to seconds results
+    // in a zero or negative value and the wallet unlocking will fail.
+    if (boost::posix_time::seconds(nSleepTime) <= boost::posix_time::seconds(0))
     {
+        pwalletMain->Lock();
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Error: The timeout value entered was incorrect.");
     }
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1963,9 +1963,9 @@ Value walletpassphrase(const Array& params, bool fHelp)
     pwalletMain->TopUpKeyPool();
 
     int64_t nSleepTime = params[1].get_int64();
-    // If the timeout value is too large, the conversion from nSleepTime to seconds results
-    // in a zero or negative value and the wallet unlocking will fail.
-    if (boost::posix_time::seconds(nSleepTime) <= boost::posix_time::seconds(0))
+    // If the timeout value is too large or negative, the conversion from nSleepTime to seconds
+    // results in a negative value and the wallet unlocking will fail.
+    if (nSleepTime > INT32_MAX || nSleepTime < 0)
     {
         pwalletMain->Lock();
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Error: The timeout value entered was incorrect.");

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1963,6 +1963,14 @@ Value walletpassphrase(const Array& params, bool fHelp)
     pwalletMain->TopUpKeyPool();
 
     int64_t nSleepTime = params[1].get_int64();
+    // Timeout limits:
+    // If the timeout is larger than the max value of int64 (922337203685477580), nSleepTime will be negative
+    // If the timeout is larger than 999999000000000, boost will not be able to convert it to seconds
+    if (nSleepTime < 0 || nSleepTime > 999999000000000)
+    {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Error: The timeout value entered was incorrect.");
+    }
+
     LOCK(cs_nWalletUnlockTime);
     nWalletUnlockTime = GetTime() + nSleepTime;
     RPCRunLater("lockwallet", boost::bind(LockWallet, pwalletMain), nSleepTime);


### PR DESCRIPTION
## Issue
When using the "walletpassphrase" command in the debug console or with the daemon, the wallet did not start staking if a value too large was entered as timeout.

## Cause
The timeout parsing and management is in rpcwallet.cpp, in the walletpassphrase function.
There are 2 limits for this timeout value:
- Entering a value larger than the max int64 value will cause the nSleepTime variable to be negative
- Entering a value larger than 999999000000000 (approximatively) will result in a negative value when calling posix_time::seconds(nSeconds) (rpcserver.cpp:665)

In both cases, the timeout becomes negative and the wallet is immediatly relocked, so the staking is aborted.

## Fix proposal
IMHO, there is no easy way to accept larger values than 999999000000000, so I added a test to handle both cases and to return an error message informing that the timeout value is incorrect.