### PR TITLE
Block explorer: do not display wrong info if a transaction is not found

### DIFF
--- a/src/qt/blockbrowser.cpp
+++ b/src/qt/blockbrowser.cpp
@@ -162,7 +162,7 @@ double getTxTotalValue(std::string txid)
     CTransaction tx;
     uint256 hashBlock = 0;
     if (!GetTransaction(hash, tx, hashBlock))
-        return 0;
+        return 1000;
 
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
     ssTx << tx;
@@ -288,7 +288,7 @@ double getTxFees(std::string txid)
     CTransaction tx;
     uint256 hashBlock = 0;
     if (!GetTransaction(hash, tx, hashBlock))
-        return 0;
+        return 51;
 
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
     ssTx << tx;
@@ -384,52 +384,43 @@ void BlockBrowser::updateExplorer(bool block)
     }
 
     if(block == false) {
-        // Display all the labels
-        ui->txLabel->show();
-        ui->valueLabel->show();
-        ui->inputLabel->show();
-        ui->outputLabel->show();
-        ui->feesLabel->show();
-
-        // Fill and display the transaction ID
-        ui->txID->show();
+        // Check if the transaction exists 
         std::string txid = ui->txBox->text().toUtf8().constData();
-        QString QID = QString::fromUtf8(txid.c_str());
-        ui->txID->setText(QID);
-
-        // Check if the transaction exists
-        uint256 hash;
-        hash.SetHex(txid);
-        
-        CTransaction tx;
-        uint256 hashBlock = 0;
-        if (GetTransaction(hash, tx, hashBlock))
-        {
-            // Transaction found: fill and display the transaction info
+        uint256 hash; 
+        hash.SetHex(txid); 
+         
+        CTransaction tx; 
+        uint256 hashBlock = 0; 
+        if (GetTransaction(hash, tx, hashBlock)) 
+        { 
+            ui->txID->show();
+            ui->txLabel->show();
+            ui->valueLabel->show();
             ui->valueBox->show();
+            ui->inputLabel->show();
             ui->inputBox->show();
+            ui->outputLabel->show();
             ui->outputBox->show();
+            ui->feesLabel->show();
             ui->feesBox->show();
             double value = getTxTotalValue(txid);
             double fees = getTxFees(txid);
             std::string outputs = getOutputs(txid);
             std::string inputs = getInputs(txid);
             QString QValue = QString::number(value, 'f', 6);
+            QString QID = QString::fromUtf8(txid.c_str());
             QString QOutputs = QString::fromUtf8(outputs.c_str());
             QString QInputs = QString::fromUtf8(inputs.c_str());
             QString QFees = QString::number(fees, 'f', 6);
             ui->valueBox->setText(QValue + " IC");
+            ui->txID->setText(QID);
             ui->outputBox->setText(QOutputs);
             ui->inputBox->setText(QInputs);
             ui->feesBox->setText(QFees + " IC");
         }
         else
         {
-            // Transaction not found: hide the info
-            ui->valueBox->hide();
-            ui->inputBox->hide();
-            ui->outputBox->hide();
-            ui->feesBox->hide();
+            QMessageBox::warning(this, tr("Transaction not found"), tr("The transaction has not been found."), QMessageBox::Ok);
         }
     }
 }

--- a/src/qt/blockbrowser.cpp
+++ b/src/qt/blockbrowser.cpp
@@ -162,7 +162,7 @@ double getTxTotalValue(std::string txid)
     CTransaction tx;
     uint256 hashBlock = 0;
     if (!GetTransaction(hash, tx, hashBlock))
-        return 1000;
+        return 0;
 
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
     ssTx << tx;
@@ -288,7 +288,7 @@ double getTxFees(std::string txid)
     CTransaction tx;
     uint256 hashBlock = 0;
     if (!GetTransaction(hash, tx, hashBlock))
-        return 51;
+        return 0;
 
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
     ssTx << tx;
@@ -384,31 +384,53 @@ void BlockBrowser::updateExplorer(bool block)
     }
 
     if(block == false) {
-        ui->txID->show();
+        // Display all the labels
         ui->txLabel->show();
         ui->valueLabel->show();
-        ui->valueBox->show();
         ui->inputLabel->show();
-        ui->inputBox->show();
         ui->outputLabel->show();
-        ui->outputBox->show();
         ui->feesLabel->show();
-        ui->feesBox->show();
+
+        // Fill and display the transaction ID
+        ui->txID->show();
         std::string txid = ui->txBox->text().toUtf8().constData();
-        double value = getTxTotalValue(txid);
-        double fees = getTxFees(txid);
-        std::string outputs = getOutputs(txid);
-        std::string inputs = getInputs(txid);
-        QString QValue = QString::number(value, 'f', 6);
         QString QID = QString::fromUtf8(txid.c_str());
-        QString QOutputs = QString::fromUtf8(outputs.c_str());
-        QString QInputs = QString::fromUtf8(inputs.c_str());
-        QString QFees = QString::number(fees, 'f', 6);
-        ui->valueBox->setText(QValue + " IC");
         ui->txID->setText(QID);
-        ui->outputBox->setText(QOutputs);
-        ui->inputBox->setText(QInputs);
-        ui->feesBox->setText(QFees + " IC");
+
+        // Check if the transaction exists
+        uint256 hash;
+        hash.SetHex(txid);
+        
+        CTransaction tx;
+        uint256 hashBlock = 0;
+        if (GetTransaction(hash, tx, hashBlock))
+        {
+            // Transaction found: fill and display the transaction info
+            ui->valueBox->show();
+            ui->inputBox->show();
+            ui->outputBox->show();
+            ui->feesBox->show();
+            double value = getTxTotalValue(txid);
+            double fees = getTxFees(txid);
+            std::string outputs = getOutputs(txid);
+            std::string inputs = getInputs(txid);
+            QString QValue = QString::number(value, 'f', 6);
+            QString QOutputs = QString::fromUtf8(outputs.c_str());
+            QString QInputs = QString::fromUtf8(inputs.c_str());
+            QString QFees = QString::number(fees, 'f', 6);
+            ui->valueBox->setText(QValue + " IC");
+            ui->outputBox->setText(QOutputs);
+            ui->inputBox->setText(QInputs);
+            ui->feesBox->setText(QFees + " IC");
+        }
+        else
+        {
+            // Transaction not found: hide the info
+            ui->valueBox->hide();
+            ui->inputBox->hide();
+            ui->outputBox->hide();
+            ui->feesBox->hide();
+        }
     }
 }
 


### PR DESCRIPTION
In the block explorer, searching for a transaction that does not exist displays wrong info (1000 value, 51 fees, etc.).
With these changes, the transaction info will be hidden if the transaction is not found.

If you prefer, I can also display a warning/error message box or write "Transaction not found" in the value field to make it clearer.