### PR TITLE
Compatibility with OpenSSL 1.1 + backward compatibility

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -47,7 +47,7 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vchRet) {
             break;
         }
         bnChar.setulong(p1 - pszBase58);
-        if (!BN_mul(&bn, &bn, &bn58, pctx))
+        if (!BN_mul(bn.to_bignum(), bn.to_bignum(), bn58.to_bignum(), pctx))
             throw bignum_error("DecodeBase58 : BN_mul failed");
         bn += bnChar;
     }

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -54,52 +54,52 @@ public:
 
 
 /** C++ wrapper for BIGNUM (OpenSSL bignum) */
-class CBigNum : public BIGNUM
+class CBigNum
 {
+    BIGNUM* bn;
+
 public:
     CBigNum()
-    {
-        BN_init(this);
-    }
+       : bn(BN_new()) {}
 
     CBigNum(const CBigNum& b)
+       : CBigNum()
     {
-        BN_init(this);
-        if (!BN_copy(this, &b))
+        if (!BN_copy(bn, b.bn))
         {
-            BN_clear_free(this);
+            BN_clear_free(bn);
             throw bignum_error("CBigNum::CBigNum(const CBigNum&) : BN_copy failed");
         }
     }
 
     CBigNum& operator=(const CBigNum& b)
     {
-        if (!BN_copy(this, &b))
+        if (!BN_copy(bn, b.bn))
             throw bignum_error("CBigNum::operator= : BN_copy failed");
         return (*this);
     }
 
     ~CBigNum()
     {
-        BN_clear_free(this);
+        BN_clear_free(bn);
     }
 
     //CBigNum(char n) is not portable.  Use 'signed char' or 'unsigned char'.
-    CBigNum(signed char n)        { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(short n)              { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(int n)                { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(long n)               { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(long long n)          { BN_init(this); setint64(n); }
-    CBigNum(unsigned char n)      { BN_init(this); setulong(n); }
-    CBigNum(unsigned short n)     { BN_init(this); setulong(n); }
-    CBigNum(unsigned int n)       { BN_init(this); setulong(n); }
-    CBigNum(unsigned long n)      { BN_init(this); setulong(n); }
-    CBigNum(unsigned long long n) { BN_init(this); setuint64(n); }
-    explicit CBigNum(uint256 n)   { BN_init(this); setuint256(n); }
+    CBigNum(signed char n)        :CBigNum() { if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(short n)              :CBigNum() {  if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(int n)                :CBigNum() {  if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(long n)               :CBigNum() {  if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(long long n)          :CBigNum() {  setint64(n); }
+    CBigNum(unsigned char n)      :CBigNum() {  setulong(n); }
+    CBigNum(unsigned short n)     :CBigNum() {  setulong(n); }
+    CBigNum(unsigned int n)       :CBigNum() {  setulong(n); }
+    CBigNum(unsigned long n)      :CBigNum() {  setulong(n); }
+    CBigNum(unsigned long long n) :CBigNum() {  setuint64(n); }
+    explicit CBigNum(uint256 n)   :CBigNum() {  setuint256(n); }
 
     explicit CBigNum(const std::vector<unsigned char>& vch)
+        : CBigNum()
     {
-        BN_init(this);
         setvch(vch);
     }
 
@@ -110,7 +110,7 @@ public:
     */
     static CBigNum  randBignum(const CBigNum& range) {
         CBigNum ret;
-        if(!BN_rand_range(&ret, &range)){
+        if(!BN_rand_range(ret.bn, range.bn)){
             throw bignum_error("CBigNum:rand element : BN_rand_range failed");
         }
         return ret;
@@ -122,7 +122,7 @@ public:
     */
     static CBigNum RandKBitBigum(const uint32_t k){
         CBigNum ret;
-        if(!BN_rand(&ret, k, -1, 0)){
+        if(!BN_rand(ret.bn, k, -1, 0)){
             throw bignum_error("CBigNum:rand element : BN_rand failed");
         }
         return ret;
@@ -133,30 +133,30 @@ public:
      * @return the size
      */
     int bitSize() const{
-        return  BN_num_bits(this);
+        return  BN_num_bits(bn);
     }
 
 
     void setulong(unsigned long n)
     {
-        if (!BN_set_word(this, n))
+        if (!BN_set_word(bn, n))
             throw bignum_error("CBigNum conversion from unsigned long : BN_set_word failed");
     }
 
     unsigned long getulong() const
     {
-        return BN_get_word(this);
+        return BN_get_word(bn);
     }
 
     unsigned int getuint() const
     {
-        return BN_get_word(this);
+        return BN_get_word(bn);
     }
 
     int getint() const
     {
-        unsigned long n = BN_get_word(this);
-        if (!BN_is_negative(this))
+        unsigned long n = BN_get_word(bn);
+        if (!BN_is_negative(bn))
             return (n > (unsigned long)std::numeric_limits<int>::max() ? std::numeric_limits<int>::max() : n);
         else
             return (n > (unsigned long)std::numeric_limits<int>::max() ? std::numeric_limits<int>::min() : -(int)n);
@@ -202,16 +202,16 @@ public:
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize) & 0xff;
-        BN_mpi2bn(pch, p - pch, this);
+        BN_mpi2bn(pch, p - pch, bn);
     }
 
     uint64_t getuint64()
     {
-        unsigned int nSize = BN_bn2mpi(this, NULL);
+        unsigned int nSize = BN_bn2mpi(bn, NULL);
         if (nSize < 4)
             return 0;
         std::vector<unsigned char> vch(nSize);
-        BN_bn2mpi(this, &vch[0]);
+        BN_bn2mpi(bn, &vch[0]);
         if (vch.size() > 4)
             vch[4] &= 0x7f;
         uint64_t n = 0;
@@ -244,7 +244,7 @@ public:
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize) & 0xff;
-        BN_mpi2bn(pch, p - pch, this);
+        BN_mpi2bn(pch, p - pch, bn);
     }
 
     void setuint256(uint256 n)
@@ -272,16 +272,16 @@ public:
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize >> 0) & 0xff;
-        BN_mpi2bn(pch, p - pch, this);
+        BN_mpi2bn(pch, p - pch, bn);
     }
 
     uint256 getuint256() const
     {
-        unsigned int nSize = BN_bn2mpi(this, NULL);
+        unsigned int nSize = BN_bn2mpi(bn, NULL);
         if (nSize < 4)
             return 0;
         std::vector<unsigned char> vch(nSize);
-        BN_bn2mpi(this, &vch[0]);
+        BN_bn2mpi(bn, &vch[0]);
         if (vch.size() > 4)
             vch[4] &= 0x7f;
         uint256 n = 0;
@@ -303,16 +303,16 @@ public:
         vch2[3] = (nSize >> 0) & 0xff;
         // swap data to big endian
         reverse_copy(vch.begin(), vch.end(), vch2.begin() + 4);
-        BN_mpi2bn(&vch2[0], vch2.size(), this);
+        BN_mpi2bn(&vch2[0], vch2.size(), bn);
     }
 
     std::vector<unsigned char> getvch() const
     {
-        unsigned int nSize = BN_bn2mpi(this, NULL);
+        unsigned int nSize = BN_bn2mpi(bn, NULL);
         if (nSize <= 4)
             return std::vector<unsigned char>();
         std::vector<unsigned char> vch(nSize);
-        BN_bn2mpi(this, &vch[0]);
+        BN_bn2mpi(bn, &vch[0]);
         vch.erase(vch.begin(), vch.begin() + 4);
         reverse(vch.begin(), vch.end());
         return vch;
@@ -326,16 +326,16 @@ public:
         if (nSize >= 1) vch[4] = (nCompact >> 16) & 0xff;
         if (nSize >= 2) vch[5] = (nCompact >> 8) & 0xff;
         if (nSize >= 3) vch[6] = (nCompact >> 0) & 0xff;
-        BN_mpi2bn(&vch[0], vch.size(), this);
+        BN_mpi2bn(&vch[0], vch.size(), bn);
         return *this;
     }
 
     unsigned int GetCompact() const
     {
-        unsigned int nSize = BN_bn2mpi(this, NULL);
+        unsigned int nSize = BN_bn2mpi(bn, NULL);
         std::vector<unsigned char> vch(nSize);
         nSize -= 4;
-        BN_bn2mpi(this, &vch[0]);
+        BN_bn2mpi(bn, &vch[0]);
         unsigned int nCompact = nSize << 24;
         if (nSize >= 1) nCompact |= (vch[4] << 16);
         if (nSize >= 2) nCompact |= (vch[5] << 8);
@@ -370,7 +370,7 @@ public:
             ++psz;
         }
         if (fNegative)
-            *this = 0 - *this;
+            BN_set_negative(bn, 1);
     }
 
     std::string ToString(int nBase=10) const
@@ -380,20 +380,20 @@ public:
         CBigNum bn0 = 0;
         std::string str;
         CBigNum bn = *this;
-        BN_set_negative(&bn, false);
+        BN_set_negative(bn.bn, false);
         CBigNum dv;
         CBigNum rem;
-        if (BN_cmp(&bn, &bn0) == 0)
+        if (BN_cmp(bn.bn, bn0.bn) == 0)
             return "0";
-        while (BN_cmp(&bn, &bn0) > 0)
+        while (BN_cmp(bn.bn, bn0.bn) > 0)
         {
-            if (!BN_div(&dv, &rem, &bn, &bnBase, pctx))
+            if (!BN_div(dv.bn, rem.bn, bn.bn, bnBase.bn, pctx))
                 throw bignum_error("CBigNum::ToString() : BN_div failed");
             bn = dv;
             unsigned int c = rem.getulong();
             str += "0123456789abcdef"[c];
         }
-        if (BN_is_negative(this))
+        if (BN_is_negative(this->bn))
             str += "-";
         reverse(str.begin(), str.end());
         return str;
@@ -440,7 +440,7 @@ public:
     CBigNum pow(const CBigNum& e) const {
         CAutoBN_CTX pctx;
         CBigNum ret;
-        if (!BN_exp(&ret, this, &e, pctx))
+        if (!BN_exp(ret.bn, bn, e.bn, pctx))
             throw bignum_error("CBigNum::pow : BN_exp failed");
         return ret;
     }
@@ -453,7 +453,7 @@ public:
     CBigNum mul_mod(const CBigNum& b, const CBigNum& m) const {
         CAutoBN_CTX pctx;
         CBigNum ret;
-        if (!BN_mod_mul(&ret, this, &b, &m, pctx))
+        if (!BN_mod_mul(ret.bn, bn, b.bn, m.bn, pctx))
             throw bignum_error("CBigNum::mul_mod : BN_mod_mul failed");
         
         return ret;
@@ -467,14 +467,15 @@ public:
     CBigNum pow_mod(const CBigNum& e, const CBigNum& m) const {
         CAutoBN_CTX pctx;
         CBigNum ret;
-        if( e < 0){
+        if(BN_is_negative(e.bn)){
             // g^-x = (g^-1)^x
             CBigNum inv = this->inverse(m);
-            CBigNum posE = e * -1;
-            if (!BN_mod_exp(&ret, &inv, &posE, &m, pctx))
+            CBigNum posE(e);
+            BN_set_negative(posE.bn, !BN_is_negative(e.bn));
+            if (!BN_mod_exp(ret.bn, inv.bn, posE.bn, m.bn, pctx))
                 throw bignum_error("CBigNum::pow_mod: BN_mod_exp failed on negative exponent");
         }else
-            if (!BN_mod_exp(&ret, this, &e, &m, pctx))
+            if (!BN_mod_exp(ret.bn, bn, e.bn, m.bn, pctx))
                 throw bignum_error("CBigNum::pow_mod : BN_mod_exp failed");
 
         return ret;
@@ -489,7 +490,7 @@ public:
     CBigNum inverse(const CBigNum& m) const {
         CAutoBN_CTX pctx;
         CBigNum ret;
-        if (!BN_mod_inverse(&ret, this, &m, pctx))
+        if (!BN_mod_inverse(ret.bn, bn, m.bn, pctx))
             throw bignum_error("CBigNum::inverse*= :BN_mod_inverse");
         return ret;
     }
@@ -502,7 +503,7 @@ public:
      */
     static CBigNum generatePrime(const unsigned int numBits, bool safe = false) {
         CBigNum ret;
-        if(!BN_generate_prime_ex(&ret, numBits, (safe == true), NULL, NULL, NULL))
+        if(!BN_generate_prime_ex(ret.bn, numBits, (safe == true), NULL, NULL, NULL))
             throw bignum_error("CBigNum::generatePrime*= :BN_generate_prime_ex");
         return ret;
     }
@@ -515,7 +516,7 @@ public:
     CBigNum gcd( const CBigNum& b) const{
         CAutoBN_CTX pctx;
         CBigNum ret;
-        if (!BN_gcd(&ret, this, &b, pctx))
+        if (!BN_gcd(ret.bn, bn, b.bn, pctx))
             throw bignum_error("CBigNum::gcd*= :BN_gcd");
         return ret;
     }
@@ -528,7 +529,7 @@ public:
     */
     bool isPrime(const int checks=BN_prime_checks) const {
         CAutoBN_CTX pctx;
-        int ret = BN_is_prime(this, checks, NULL, pctx, NULL);
+        int ret = BN_is_prime(bn, checks, NULL, pctx, NULL);
         if(ret < 0){
             throw bignum_error("CBigNum::isPrime :BN_is_prime");
         }
@@ -536,51 +537,56 @@ public:
     }
 
     bool isOne() const {
-        return BN_is_one(this);
+        return BN_is_one(bn);
     }
 
 
     bool operator!() const
     {
-        return BN_is_zero(this);
+        return BN_is_zero(bn);
     }
 
     CBigNum& operator+=(const CBigNum& b)
     {
-        if (!BN_add(this, this, &b))
+        if (!BN_add(bn, bn, b.bn))
             throw bignum_error("CBigNum::operator+= : BN_add failed");
         return *this;
     }
 
     CBigNum& operator-=(const CBigNum& b)
     {
-        *this = *this - b;
+        if (!BN_sub(bn, bn, b.bn))
+            throw bignum_error("CBigNum::operator-= : BN_sub failed");
         return *this;
     }
 
     CBigNum& operator*=(const CBigNum& b)
     {
         CAutoBN_CTX pctx;
-        if (!BN_mul(this, this, &b, pctx))
+        if (!BN_mul(bn, bn, b.bn, pctx))
             throw bignum_error("CBigNum::operator*= : BN_mul failed");
         return *this;
     }
 
     CBigNum& operator/=(const CBigNum& b)
     {
-        *this = *this / b;
+        CAutoBN_CTX pctx;
+        if (!BN_div(bn, NULL, bn, b.bn, pctx))
+            throw bignum_error("CBigNum::operator/= : BN_div failed");
         return *this;
     }
 
     CBigNum& operator%=(const CBigNum& b)
     {
-        *this = *this % b;
+        CAutoBN_CTX pctx;
+        if (!BN_div(NULL, bn, bn, b.bn, pctx))
+            throw bignum_error("CBigNum::operator%= : BN_div failed");
         return *this;
     }
 
     CBigNum& operator<<=(unsigned int shift)
     {
-        if (!BN_lshift(this, this, shift))
+        if (!BN_lshift(bn, bn, shift))
             throw bignum_error("CBigNum:operator<<= : BN_lshift failed");
         return *this;
     }
@@ -591,13 +597,13 @@ public:
         //   if built on ubuntu 9.04 or 9.10, probably depends on version of OpenSSL
         CBigNum a = 1;
         a <<= shift;
-        if (BN_cmp(&a, this) > 0)
+        if (BN_cmp(a.bn, bn) > 0)
         {
             *this = 0;
             return *this;
         }
 
-        if (!BN_rshift(this, this, shift))
+        if (!BN_rshift(bn, bn, shift))
             throw bignum_error("CBigNum:operator>>= : BN_rshift failed");
         return *this;
     }
@@ -606,7 +612,7 @@ public:
     CBigNum& operator++()
     {
         // prefix operator
-        if (!BN_add(this, this, BN_value_one()))
+        if (!BN_add(bn, bn, BN_value_one()))
             throw bignum_error("CBigNum::operator++ : BN_add failed");
         return *this;
     }
@@ -623,7 +629,7 @@ public:
     {
         // prefix operator
         CBigNum r;
-        if (!BN_sub(&r, this, BN_value_one()))
+        if (!BN_sub(r.bn, bn, BN_value_one()))
             throw bignum_error("CBigNum::operator-- : BN_sub failed");
         *this = r;
         return *this;
@@ -638,11 +644,12 @@ public:
     }
 
 
-    friend inline const CBigNum operator-(const CBigNum& a, const CBigNum& b);
-    friend inline const CBigNum operator/(const CBigNum& a, const CBigNum& b);
-    friend inline const CBigNum operator%(const CBigNum& a, const CBigNum& b);
-    friend inline const CBigNum operator*(const CBigNum& a, const CBigNum& b);
-    friend inline bool operator<(const CBigNum& a, const CBigNum& b);
+    const BIGNUM* to_bignum() const {
+       return bn;
+    }
+    BIGNUM* to_bignum() {
+       return bn;
+    }
 };
 
 
@@ -650,7 +657,7 @@ public:
 inline const CBigNum operator+(const CBigNum& a, const CBigNum& b)
 {
     CBigNum r;
-    if (!BN_add(&r, &a, &b))
+    if (!BN_add(r.to_bignum(), a.to_bignum(), b.to_bignum()))
         throw bignum_error("CBigNum::operator+ : BN_add failed");
     return r;
 }
@@ -658,7 +665,7 @@ inline const CBigNum operator+(const CBigNum& a, const CBigNum& b)
 inline const CBigNum operator-(const CBigNum& a, const CBigNum& b)
 {
     CBigNum r;
-    if (!BN_sub(&r, &a, &b))
+    if (!BN_sub(r.to_bignum(), a.to_bignum(), b.to_bignum()))
         throw bignum_error("CBigNum::operator- : BN_sub failed");
     return r;
 }
@@ -666,7 +673,7 @@ inline const CBigNum operator-(const CBigNum& a, const CBigNum& b)
 inline const CBigNum operator-(const CBigNum& a)
 {
     CBigNum r(a);
-    BN_set_negative(&r, !BN_is_negative(&r));
+    BN_set_negative(r.to_bignum(), !BN_is_negative(r.to_bignum()));
     return r;
 }
 
@@ -674,7 +681,7 @@ inline const CBigNum operator*(const CBigNum& a, const CBigNum& b)
 {
     CAutoBN_CTX pctx;
     CBigNum r;
-    if (!BN_mul(&r, &a, &b, pctx))
+    if (!BN_mul(r.to_bignum(), a.to_bignum(), b.to_bignum(), pctx))
         throw bignum_error("CBigNum::operator* : BN_mul failed");
     return r;
 }
@@ -683,7 +690,7 @@ inline const CBigNum operator/(const CBigNum& a, const CBigNum& b)
 {
     CAutoBN_CTX pctx;
     CBigNum r;
-    if (!BN_div(&r, NULL, &a, &b, pctx))
+    if (!BN_div(r.to_bignum(), NULL, a.to_bignum(), b.to_bignum(), pctx))
         throw bignum_error("CBigNum::operator/ : BN_div failed");
     return r;
 }
@@ -692,7 +699,7 @@ inline const CBigNum operator%(const CBigNum& a, const CBigNum& b)
 {
     CAutoBN_CTX pctx;
     CBigNum r;
-    if (!BN_nnmod(&r, &a, &b, pctx))
+    if (!BN_nnmod(r.to_bignum(), a.to_bignum(), b.to_bignum(), pctx))
         throw bignum_error("CBigNum::operator% : BN_div failed");
     return r;
 }
@@ -700,7 +707,7 @@ inline const CBigNum operator%(const CBigNum& a, const CBigNum& b)
 inline const CBigNum operator<<(const CBigNum& a, unsigned int shift)
 {
     CBigNum r;
-    if (!BN_lshift(&r, &a, shift))
+    if (!BN_lshift(r.to_bignum(), a.to_bignum(), shift))
         throw bignum_error("CBigNum:operator<< : BN_lshift failed");
     return r;
 }
@@ -712,12 +719,12 @@ inline const CBigNum operator>>(const CBigNum& a, unsigned int shift)
     return r;
 }
 
-inline bool operator==(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) == 0); }
-inline bool operator!=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) != 0); }
-inline bool operator<=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) <= 0); }
-inline bool operator>=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) >= 0); }
-inline bool operator<(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(&a, &b) < 0); }
-inline bool operator>(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(&a, &b) > 0); }
+inline bool operator==(const CBigNum& a, const CBigNum& b) { return (BN_cmp(a.to_bignum(), b.to_bignum()) == 0); }
+inline bool operator!=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(a.to_bignum(), b.to_bignum()) != 0); }
+inline bool operator<=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(a.to_bignum(), b.to_bignum()) <= 0); }
+inline bool operator>=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(a.to_bignum(), b.to_bignum()) >= 0); }
+inline bool operator<(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(a.to_bignum(), b.to_bignum()) < 0); }
+inline bool operator>(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(a.to_bignum(), b.to_bignum()) > 0); }
 
 inline std::ostream& operator<<(std::ostream &strm, const CBigNum &b) { return strm << b.ToString(10); }
 

--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -78,15 +78,16 @@ bool CCrypter::Encrypt(const CKeyingMaterial& vchPlaintext, std::vector<unsigned
     int nCLen = nLen + AES_BLOCK_SIZE, nFLen = 0;
     vchCiphertext = std::vector<unsigned char> (nCLen);
 
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
     bool fOk = true;
 
-    EVP_CIPHER_CTX_init(&ctx);
-    if (fOk) fOk = EVP_EncryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
-    if (fOk) fOk = EVP_EncryptUpdate(&ctx, &vchCiphertext[0], &nCLen, &vchPlaintext[0], nLen);
-    if (fOk) fOk = EVP_EncryptFinal_ex(&ctx, (&vchCiphertext[0])+nCLen, &nFLen);
-    EVP_CIPHER_CTX_cleanup(&ctx);
+    EVP_CIPHER_CTX_init(ctx);
+    if (fOk) fOk = EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
+    if (fOk) fOk = EVP_EncryptUpdate(ctx, &vchCiphertext[0], &nCLen, &vchPlaintext[0], nLen);
+    if (fOk) fOk = EVP_EncryptFinal_ex(ctx, (&vchCiphertext[0])+nCLen, &nFLen);
+    EVP_CIPHER_CTX_cleanup(ctx);
+    EVP_CIPHER_CTX_free(ctx);
 
     if (!fOk) return false;
 
@@ -105,15 +106,16 @@ bool CCrypter::Decrypt(const std::vector<unsigned char>& vchCiphertext, CKeyingM
 
     vchPlaintext = CKeyingMaterial(nPLen);
 
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
     bool fOk = true;
 
-    EVP_CIPHER_CTX_init(&ctx);
-    if (fOk) fOk = EVP_DecryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
-    if (fOk) fOk = EVP_DecryptUpdate(&ctx, &vchPlaintext[0], &nPLen, &vchCiphertext[0], nLen);
-    if (fOk) fOk = EVP_DecryptFinal_ex(&ctx, (&vchPlaintext[0])+nPLen, &nFLen);
-    EVP_CIPHER_CTX_cleanup(&ctx);
+    EVP_CIPHER_CTX_init(ctx);
+    if (fOk) fOk = EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
+    if (fOk) fOk = EVP_DecryptUpdate(ctx, &vchPlaintext[0], &nPLen, &vchCiphertext[0], nLen);
+    if (fOk) fOk = EVP_DecryptFinal_ex(ctx, (&vchPlaintext[0])+nPLen, &nFLen);
+    EVP_CIPHER_CTX_cleanup(ctx);
+    EVP_CIPHER_CTX_free(ctx);
 
     if (!fOk) return false;
 
@@ -161,15 +163,16 @@ bool EncryptAES256(const SecureString& sKey, const SecureString& sPlaintext, con
     sCiphertext.resize(nCLen);
 
     // Perform the encryption
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
     bool fOk = true;
 
-    EVP_CIPHER_CTX_init(&ctx);
-    if (fOk) fOk = EVP_EncryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, (const unsigned char*) &sKey[0], (const unsigned char*) &sIV[0]);
-    if (fOk) fOk = EVP_EncryptUpdate(&ctx, (unsigned char*) &sCiphertext[0], &nCLen, (const unsigned char*) &sPlaintext[0], nLen);
-    if (fOk) fOk = EVP_EncryptFinal_ex(&ctx, (unsigned char*) (&sCiphertext[0])+nCLen, &nFLen);
-    EVP_CIPHER_CTX_cleanup(&ctx);
+    EVP_CIPHER_CTX_init(ctx);
+    if (fOk) fOk = EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, (const unsigned char*) &sKey[0], (const unsigned char*) &sIV[0]);
+    if (fOk) fOk = EVP_EncryptUpdate(ctx, (unsigned char*) &sCiphertext[0], &nCLen, (const unsigned char*) &sPlaintext[0], nLen);
+    if (fOk) fOk = EVP_EncryptFinal_ex(ctx, (unsigned char*) (&sCiphertext[0])+nCLen, &nFLen);
+    EVP_CIPHER_CTX_cleanup(ctx);
+    EVP_CIPHER_CTX_free(ctx);
 
     if (!fOk) return false;
 
@@ -191,15 +194,16 @@ bool DecryptAES256(const SecureString& sKey, const std::string& sCiphertext, con
 
     sPlaintext.resize(nPLen);
 
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
     bool fOk = true;
 
-    EVP_CIPHER_CTX_init(&ctx);
-    if (fOk) fOk = EVP_DecryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, (const unsigned char*) &sKey[0], (const unsigned char*) &sIV[0]);
-    if (fOk) fOk = EVP_DecryptUpdate(&ctx, (unsigned char *) &sPlaintext[0], &nPLen, (const unsigned char *) &sCiphertext[0], nLen);
-    if (fOk) fOk = EVP_DecryptFinal_ex(&ctx, (unsigned char *) (&sPlaintext[0])+nPLen, &nFLen);
-    EVP_CIPHER_CTX_cleanup(&ctx);
+    EVP_CIPHER_CTX_init(ctx);
+    if (fOk) fOk = EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, (const unsigned char*) &sKey[0], (const unsigned char*) &sIV[0]);
+    if (fOk) fOk = EVP_DecryptUpdate(ctx, (unsigned char *) &sPlaintext[0], &nPLen, (const unsigned char *) &sCiphertext[0], nLen);
+    if (fOk) fOk = EVP_DecryptFinal_ex(ctx, (unsigned char *) (&sPlaintext[0])+nPLen, &nFLen);
+    EVP_CIPHER_CTX_cleanup(ctx);
+    EVP_CIPHER_CTX_free(ctx);
 
     if (!fOk) return false;
 

--- a/src/ecwrapper.cpp
+++ b/src/ecwrapper.cpp
@@ -231,6 +231,8 @@ bool CECKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig) {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
         ECDSA_SIG_set0(sig, sig_r_new, sig_s_new);
 #else
+        BN_clear_free(sig->r);
+        BN_clear_free(sig->s);
         sig->r = sig_r_new;
         sig->s = sig_s_new;
 #endif
@@ -307,6 +309,8 @@ bool CECKey::Recover(const uint256 &hash, const unsigned char *p64, int rec)
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
     ECDSA_SIG_set0(sig, sig_r, sig_s);
 #else
+    BN_clear_free(sig->r);
+    BN_clear_free(sig->s);
     sig->r = sig_r;
     sig->s = sig_s;
 #endif

--- a/src/ecwrapper.cpp
+++ b/src/ecwrapper.cpp
@@ -74,6 +74,10 @@ int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned ch
     int n = 0;
     int i = recid / 2;
 
+    const BIGNUM *ecsig_r = NULL;
+    const BIGNUM *ecsig_s = NULL;
+    ECDSA_SIG_get0(ecsig, &ecsig_r, &ecsig_s);
+
     const EC_GROUP *group = EC_KEY_get0_group(eckey);
     if ((ctx = BN_CTX_new()) == NULL) { ret = -1; goto err; }
     BN_CTX_start(ctx);
@@ -82,7 +86,7 @@ int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned ch
     x = BN_CTX_get(ctx);
     if (!BN_copy(x, order)) { ret=-1; goto err; }
     if (!BN_mul_word(x, i)) { ret=-1; goto err; }
-    if (!BN_add(x, x, ecsig->r)) { ret=-1; goto err; }
+    if (!BN_add(x, x, ecsig_r)) { ret=-1; goto err; }
     field = BN_CTX_get(ctx);
     if (!EC_GROUP_get_curve_GFp(group, field, NULL, NULL, ctx)) { ret=-2; goto err; }
     if (BN_cmp(x, field) >= 0) { ret=0; goto err; }
@@ -103,9 +107,9 @@ int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned ch
     if (!BN_zero(zero)) { ret=-1; goto err; }
     if (!BN_mod_sub(e, zero, e, order, ctx)) { ret=-1; goto err; }
     rr = BN_CTX_get(ctx);
-    if (!BN_mod_inverse(rr, ecsig->r, order, ctx)) { ret=-1; goto err; }
+    if (!BN_mod_inverse(rr, ecsig_r, order, ctx)) { ret=-1; goto err; }
     sor = BN_CTX_get(ctx);
-    if (!BN_mod_mul(sor, ecsig->s, rr, order, ctx)) { ret=-1; goto err; }
+    if (!BN_mod_mul(sor, ecsig_s, rr, order, ctx)) { ret=-1; goto err; }
     eor = BN_CTX_get(ctx);
     if (!BN_mod_mul(eor, e, rr, order, ctx)) { ret=-1; goto err; }
     if (!EC_POINT_mul(group, Q, eor, R, sor, ctx)) { ret=-2; goto err; }
@@ -146,13 +150,12 @@ void CECKey::GetSecretBytes(unsigned char vch[32]) const {
 
 void CECKey::SetSecretBytes(const unsigned char vch[32]) {
     bool ret;
-    BIGNUM bn;
-    BN_init(&bn);
-    ret = BN_bin2bn(vch, 32, &bn) != NULL;
+    BIGNUM* bn(BN_new());
+    ret = BN_bin2bn(vch, 32, bn) != NULL;
     assert(ret);
-    ret = EC_KEY_regenerate_key(pkey, &bn) != 0;
+    ret = EC_KEY_regenerate_key(pkey, bn) != 0;
     assert(ret);
-    BN_clear_free(&bn);
+    BN_clear_free(bn);
 }
 
 int CECKey::GetPrivKeySize(bool fCompressed) {
@@ -198,6 +201,11 @@ bool CECKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig) {
     ECDSA_SIG *sig = ECDSA_do_sign((unsigned char*)&hash, sizeof(hash), pkey);
     if (sig == NULL)
         return false;
+
+    const BIGNUM *sig_r = NULL;
+    const BIGNUM *sig_s = NULL;
+    ECDSA_SIG_get0(sig, &sig_r, &sig_s);
+        
     BN_CTX *ctx = BN_CTX_new();
     BN_CTX_start(ctx);
     const EC_GROUP *group = EC_KEY_get0_group(pkey);
@@ -205,9 +213,12 @@ bool CECKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig) {
     BIGNUM *halforder = BN_CTX_get(ctx);
     EC_GROUP_get_order(group, order, ctx);
     BN_rshift1(halforder, order);
-    if (BN_cmp(sig->s, halforder) > 0) {
+    if (BN_cmp(sig_s, halforder) > 0) {
         // enforce low S values, by negating the value (modulo the order) if above order/2.
-        BN_sub(sig->s, order, sig->s);
+        BIGNUM *sig_s_new = BN_dup(sig_s);
+        BIGNUM *sig_r_new = BN_dup(sig_r);
+        BN_sub(sig_s_new, order, sig_s);
+        ECDSA_SIG_set0(sig, sig_r_new, sig_s_new);
     }
     BN_CTX_end(ctx);
     BN_CTX_free(ctx);
@@ -232,9 +243,14 @@ bool CECKey::SignCompact(const uint256 &hash, unsigned char *p64, int &rec) {
     ECDSA_SIG *sig = ECDSA_do_sign((unsigned char*)&hash, sizeof(hash), pkey);
     if (sig==NULL)
         return false;
+
+    const BIGNUM *sig_r = NULL;
+    const BIGNUM *sig_s = NULL;
+    ECDSA_SIG_get0(sig, &sig_r, &sig_s);
+        
     memset(p64, 0, 64);
-    int nBitsR = BN_num_bits(sig->r);
-    int nBitsS = BN_num_bits(sig->s);
+    int nBitsR = BN_num_bits(sig_r);
+    int nBitsS = BN_num_bits(sig_s);
     if (nBitsR <= 256 && nBitsS <= 256) {
         std::vector<unsigned char> pubkey;
         GetPubKey(pubkey, true);
@@ -251,8 +267,8 @@ bool CECKey::SignCompact(const uint256 &hash, unsigned char *p64, int &rec) {
             }
         }
         assert(fOk);
-        BN_bn2bin(sig->r,&p64[32-(nBitsR+7)/8]);
-        BN_bn2bin(sig->s,&p64[64-(nBitsS+7)/8]);
+        BN_bn2bin(sig_r,&p64[32-(nBitsR+7)/8]);
+        BN_bn2bin(sig_s,&p64[64-(nBitsS+7)/8]);
     }
     ECDSA_SIG_free(sig);
     return fOk;
@@ -263,8 +279,12 @@ bool CECKey::Recover(const uint256 &hash, const unsigned char *p64, int rec)
     if (rec<0 || rec>=3)
         return false;
     ECDSA_SIG *sig = ECDSA_SIG_new();
-    BN_bin2bn(&p64[0],  32, sig->r);
-    BN_bin2bn(&p64[32], 32, sig->s);
+    BIGNUM *sig_r(BN_new());
+    BIGNUM *sig_s(BN_new());
+    
+    BN_bin2bn(&p64[0],  32, sig_r);
+    BN_bin2bn(&p64[32], 32, sig_s);
+    ECDSA_SIG_set0(sig, sig_r, sig_s);
     bool ret = ECDSA_SIG_recover_key_GFp(pkey, sig, (unsigned char*)&hash, sizeof(hash), rec, 0) == 1;
     ECDSA_SIG_free(sig);
     return ret;

--- a/src/ecwrapper.cpp
+++ b/src/ecwrapper.cpp
@@ -76,7 +76,12 @@ int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned ch
 
     const BIGNUM *ecsig_r = NULL;
     const BIGNUM *ecsig_s = NULL;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
     ECDSA_SIG_get0(ecsig, &ecsig_r, &ecsig_s);
+#else
+    ecsig_r = ecsig->r;
+    ecsig_s = ecsig->s;
+#endif
 
     const EC_GROUP *group = EC_KEY_get0_group(eckey);
     if ((ctx = BN_CTX_new()) == NULL) { ret = -1; goto err; }
@@ -204,7 +209,12 @@ bool CECKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig) {
 
     const BIGNUM *sig_r = NULL;
     const BIGNUM *sig_s = NULL;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
     ECDSA_SIG_get0(sig, &sig_r, &sig_s);
+#else
+    sig_r = sig->r;
+    sig_s = sig->s;
+#endif
         
     BN_CTX *ctx = BN_CTX_new();
     BN_CTX_start(ctx);
@@ -218,7 +228,12 @@ bool CECKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig) {
         BIGNUM *sig_s_new = BN_dup(sig_s);
         BIGNUM *sig_r_new = BN_dup(sig_r);
         BN_sub(sig_s_new, order, sig_s);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
         ECDSA_SIG_set0(sig, sig_r_new, sig_s_new);
+#else
+        sig->r = sig_r_new;
+        sig->s = sig_s_new;
+#endif
     }
     BN_CTX_end(ctx);
     BN_CTX_free(ctx);
@@ -246,7 +261,12 @@ bool CECKey::SignCompact(const uint256 &hash, unsigned char *p64, int &rec) {
 
     const BIGNUM *sig_r = NULL;
     const BIGNUM *sig_s = NULL;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
     ECDSA_SIG_get0(sig, &sig_r, &sig_s);
+#else
+    sig_r = sig->r;
+    sig_s = sig->s;
+#endif
         
     memset(p64, 0, 64);
     int nBitsR = BN_num_bits(sig_r);
@@ -284,7 +304,12 @@ bool CECKey::Recover(const uint256 &hash, const unsigned char *p64, int rec)
     
     BN_bin2bn(&p64[0],  32, sig_r);
     BN_bin2bn(&p64[32], 32, sig_s);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
     ECDSA_SIG_set0(sig, sig_r, sig_s);
+#else
+    sig->r = sig_r;
+    sig->s = sig_s;
+#endif
     bool ret = ECDSA_SIG_recover_key_GFp(pkey, sig, (unsigned char*)&hash, sizeof(hash), rec, 0) == 1;
     ECDSA_SIG_free(sig);
     return ret;

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1000,17 +1000,17 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                         break;
 
                     case OP_MUL:
-                        if (!BN_mul(&bn, &bn1, &bn2, pctx))
+                        if (!BN_mul(bn.to_bignum(), bn1.to_bignum(), bn2.to_bignum(), pctx))
                             return false;
                         break;
 
                     case OP_DIV:
-                        if (!BN_div(&bn, NULL, &bn1, &bn2, pctx))
+                        if (!BN_div(bn.to_bignum(), NULL, bn1.to_bignum(), bn2.to_bignum(), pctx))
                             return false;
                         break;
 
                     case OP_MOD:
-                        if (!BN_mod(&bn, &bn1, &bn2, pctx))
+                        if (!BN_mod(bn.to_bignum(), bn1.to_bignum(), bn2.to_bignum(), pctx))
                             return false;
                         break;
 

--- a/src/secp256k1/src/tests.c
+++ b/src/secp256k1/src/tests.c
@@ -3557,7 +3557,12 @@ int test_ecdsa_der_parse(const unsigned char *sig, size_t siglen, int certainly_
     sig_openssl = ECDSA_SIG_new();
     const BIGNUM *sig_openssl_r = NULL;
     const BIGNUM *sig_openssl_s = NULL;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
     ECDSA_SIG_get0(sig_openssl, &sig_openssl_r, &sig_openssl_s);
+#else
+    sig_openssl_r = sig_openssl->r;
+    sig_openssl_s = sig_openssl->s;
+#endif
     
     sigptr = sig;
     parsed_openssl = (d2i_ECDSA_SIG(&sig_openssl, &sigptr, siglen) != NULL);

--- a/src/secp256k1/src/tests.c
+++ b/src/secp256k1/src/tests.c
@@ -3555,18 +3555,22 @@ int test_ecdsa_der_parse(const unsigned char *sig, size_t siglen, int certainly_
 
 #ifdef ENABLE_OPENSSL_TESTS
     sig_openssl = ECDSA_SIG_new();
+    const BIGNUM *sig_openssl_r = NULL;
+    const BIGNUM *sig_openssl_s = NULL;
+    ECDSA_SIG_get0(sig_openssl, &sig_openssl_r, &sig_openssl_s);
+    
     sigptr = sig;
     parsed_openssl = (d2i_ECDSA_SIG(&sig_openssl, &sigptr, siglen) != NULL);
     if (parsed_openssl) {
-        valid_openssl = !BN_is_negative(sig_openssl->r) && !BN_is_negative(sig_openssl->s) && BN_num_bits(sig_openssl->r) > 0 && BN_num_bits(sig_openssl->r) <= 256 && BN_num_bits(sig_openssl->s) > 0 && BN_num_bits(sig_openssl->s) <= 256;
+        valid_openssl = !BN_is_negative(sig_openssl_r) && !BN_is_negative(sig_openssl_s) && BN_num_bits(sig_openssl_r) > 0 && BN_num_bits(sig_openssl_r) <= 256 && BN_num_bits(sig_openssl_s) > 0 && BN_num_bits(sig_openssl_s) <= 256;
         if (valid_openssl) {
             unsigned char tmp[32] = {0};
-            BN_bn2bin(sig_openssl->r, tmp + 32 - BN_num_bytes(sig_openssl->r));
+            BN_bn2bin(sig_openssl_r, tmp + 32 - BN_num_bytes(sig_openssl_r));
             valid_openssl = memcmp(tmp, max_scalar, 32) < 0;
         }
         if (valid_openssl) {
             unsigned char tmp[32] = {0};
-            BN_bn2bin(sig_openssl->s, tmp + 32 - BN_num_bytes(sig_openssl->s));
+            BN_bn2bin(sig_openssl_s, tmp + 32 - BN_num_bytes(sig_openssl_s));
             valid_openssl = memcmp(tmp, max_scalar, 32) < 0;
         }
     }

--- a/src/smessage.cpp
+++ b/src/smessage.cpp
@@ -115,15 +115,16 @@ bool SecMsgCrypter::Encrypt(uint8_t* chPlaintext, uint32_t nPlain, std::vector<u
     int nCLen = nLen + AES_BLOCK_SIZE, nFLen = 0;
     vchCiphertext = std::vector<uint8_t> (nCLen);
 
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
     bool fOk = true;
 
-    EVP_CIPHER_CTX_init(&ctx);
-    if (fOk) fOk = EVP_EncryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, &chKey[0], &chIV[0]);
-    if (fOk) fOk = EVP_EncryptUpdate(&ctx, &vchCiphertext[0], &nCLen, chPlaintext, nLen);
-    if (fOk) fOk = EVP_EncryptFinal_ex(&ctx, (&vchCiphertext[0])+nCLen, &nFLen);
-    EVP_CIPHER_CTX_cleanup(&ctx);
+    EVP_CIPHER_CTX_init(ctx);
+    if (fOk) fOk = EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, &chKey[0], &chIV[0]);
+    if (fOk) fOk = EVP_EncryptUpdate(ctx, &vchCiphertext[0], &nCLen, chPlaintext, nLen);
+    if (fOk) fOk = EVP_EncryptFinal_ex(ctx, (&vchCiphertext[0])+nCLen, &nFLen);
+    EVP_CIPHER_CTX_cleanup(ctx);
+    EVP_CIPHER_CTX_free(ctx);
 
     if (!fOk)
         return false;
@@ -143,15 +144,16 @@ bool SecMsgCrypter::Decrypt(uint8_t* chCiphertext, uint32_t nCipher, std::vector
 
     vchPlaintext.resize(nCipher);
 
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
     bool fOk = true;
 
-    EVP_CIPHER_CTX_init(&ctx);
-    if (fOk) fOk = EVP_DecryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, &chKey[0], &chIV[0]);
-    if (fOk) fOk = EVP_DecryptUpdate(&ctx, &vchPlaintext[0], &nPLen, &chCiphertext[0], nCipher);
-    if (fOk) fOk = EVP_DecryptFinal_ex(&ctx, (&vchPlaintext[0])+nPLen, &nFLen);
-    EVP_CIPHER_CTX_cleanup(&ctx);
+    EVP_CIPHER_CTX_init(ctx);
+    if (fOk) fOk = EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, &chKey[0], &chIV[0]);
+    if (fOk) fOk = EVP_DecryptUpdate(ctx, &vchPlaintext[0], &nPLen, &chCiphertext[0], nCipher);
+    if (fOk) fOk = EVP_DecryptFinal_ex(ctx, (&vchPlaintext[0])+nPLen, &nFLen);
+    EVP_CIPHER_CTX_cleanup(ctx);
+    EVP_CIPHER_CTX_free(ctx);
 
     if (!fOk)
         return false;
@@ -3127,15 +3129,14 @@ int SecureMsgValidate(uint8_t *pHeader, uint8_t *pPayload, uint32_t nPayload)
     for (int i = 0; i < 32; i+=4)
         memcpy(civ+i, &nonse, 4);
 
-    HMAC_CTX ctx;
-    HMAC_CTX_init(&ctx);
+    HMAC_CTX *ctx = HMAC_CTX_new();
 
     uint32_t nBytes;
-    if (!HMAC_Init_ex(&ctx, &civ[0], 32, EVP_sha256(), NULL)
-        || !HMAC_Update(&ctx, (uint8_t*) pHeader+4, SMSG_HDR_LEN-4)
-        || !HMAC_Update(&ctx, (uint8_t*) pPayload, nPayload)
-        || !HMAC_Update(&ctx, pPayload, nPayload)
-        || !HMAC_Final(&ctx, sha256Hash, &nBytes)
+    if (!HMAC_Init_ex(ctx, &civ[0], 32, EVP_sha256(), NULL)
+        || !HMAC_Update(ctx, (uint8_t*) pHeader+4, SMSG_HDR_LEN-4)
+        || !HMAC_Update(ctx, (uint8_t*) pPayload, nPayload)
+        || !HMAC_Update(ctx, pPayload, nPayload)
+        || !HMAC_Final(ctx, sha256Hash, &nBytes)
         || nBytes != 32)
     {
         if (fDebugSmsg)
@@ -3159,7 +3160,7 @@ int SecureMsgValidate(uint8_t *pHeader, uint8_t *pPayload, uint32_t nPayload)
             rv = 3; // checksum mismatch
         }
     }
-    HMAC_CTX_cleanup(&ctx);
+    HMAC_CTX_free(ctx);
 
     return rv;
 };
@@ -3184,8 +3185,7 @@ int SecureMsgSetHash(uint8_t *pHeader, uint8_t *pPayload, uint32_t nPayload)
     uint8_t sha256Hash[32];
 
     bool found = false;
-    HMAC_CTX ctx;
-    HMAC_CTX_init(&ctx);
+    HMAC_CTX *ctx = HMAC_CTX_new();
 
     uint32_t nonse = 0;
 
@@ -3206,12 +3206,12 @@ int SecureMsgSetHash(uint8_t *pHeader, uint8_t *pPayload, uint32_t nPayload)
             memcpy(civ+i, &nonse, 4);
 
         uint32_t nBytes;
-        if (!HMAC_Init_ex(&ctx, &civ[0], 32, EVP_sha256(), NULL)
-            || !HMAC_Update(&ctx, (uint8_t*) pHeader+4, SMSG_HDR_LEN-4)
-            || !HMAC_Update(&ctx, (uint8_t*) pPayload, nPayload)
-            || !HMAC_Update(&ctx, pPayload, nPayload)
-            || !HMAC_Final(&ctx, sha256Hash, &nBytes)
-            //|| !HMAC_Final(&ctx, &vchHash[0], &nBytes)
+        if (!HMAC_Init_ex(ctx, &civ[0], 32, EVP_sha256(), NULL)
+            || !HMAC_Update(ctx, (uint8_t*) pHeader+4, SMSG_HDR_LEN-4)
+            || !HMAC_Update(ctx, (uint8_t*) pPayload, nPayload)
+            || !HMAC_Update(ctx, pPayload, nPayload)
+            || !HMAC_Final(ctx, sha256Hash, &nBytes)
+            //|| !HMAC_Final(ctx, &vchHash[0], &nBytes)
             || nBytes != 32)
             break;
 
@@ -3247,7 +3247,7 @@ int SecureMsgSetHash(uint8_t *pHeader, uint8_t *pPayload, uint32_t nPayload)
         nonse++;
     };
 
-    HMAC_CTX_cleanup(&ctx);
+    HMAC_CTX_free(ctx);
 
     if (!fSecMsgEnabled)
     {
@@ -3389,7 +3389,7 @@ int SecureMsgEncrypt(SecureMessage &smsg, const std::string &addressFrom, const 
     //LogPrint("smessage", "secret_len %d.\n", secret_len);
 
     // -- ECDH_compute_key returns the same P if fed compressed or uncompressed public keys
-    ECDH_set_method(pkeyr, ECDH_OpenSSL());
+    EC_KEY_set_method(pkeyK, EC_KEY_OpenSSL());
     int lenP = ECDH_compute_key(&vchP[0], 32, EC_KEY_get0_public_key(pkeyK), pkeyr, NULL);
 
     if (lenP != 32)
@@ -3509,17 +3509,16 @@ int SecureMsgEncrypt(SecureMessage &smsg, const std::string &addressFrom, const 
     //    Message authentication code, (hash of timestamp + destination + payload)
     bool fHmacOk = true;
     uint32_t nBytes = 32;
-    HMAC_CTX ctx;
-    HMAC_CTX_init(&ctx);
+    HMAC_CTX *ctx = HMAC_CTX_new();
 
-    if (!HMAC_Init_ex(&ctx, &key_m[0], 32, EVP_sha256(), NULL)
-        || !HMAC_Update(&ctx, (uint8_t*) &smsg.timestamp, sizeof(smsg.timestamp))
-        || !HMAC_Update(&ctx, &vchCiphertext[0], vchCiphertext.size())
-        || !HMAC_Final(&ctx, smsg.mac, &nBytes)
+    if (!HMAC_Init_ex(ctx, &key_m[0], 32, EVP_sha256(), NULL)
+        || !HMAC_Update(ctx, (uint8_t*) &smsg.timestamp, sizeof(smsg.timestamp))
+        || !HMAC_Update(ctx, &vchCiphertext[0], vchCiphertext.size())
+        || !HMAC_Final(ctx, smsg.mac, &nBytes)
         || nBytes != 32)
         fHmacOk = false;
 
-    HMAC_CTX_cleanup(&ctx);
+    HMAC_CTX_free(ctx);
 
     if (!fHmacOk)
     {
@@ -3772,7 +3771,7 @@ int SecureMsgDecrypt(bool fTestOnly, std::string &address, uint8_t *pHeader, uin
     EC_KEY* pkeyk = ecKeyDest.GetECKey();
     EC_KEY* pkeyR = ecKeyR.GetECKey();
 
-    ECDH_set_method(pkeyk, ECDH_OpenSSL());
+    EC_KEY_set_method(pkeyk, EC_KEY_OpenSSL());
     int lenPdec = ECDH_compute_key(&vchP[0], 32, EC_KEY_get0_public_key(pkeyR), pkeyk, NULL);
 
     if (lenPdec != 32)
@@ -3794,17 +3793,16 @@ int SecureMsgDecrypt(bool fTestOnly, std::string &address, uint8_t *pHeader, uin
     uint8_t MAC[32];
     bool fHmacOk = true;
     uint32_t nBytes = 32;
-    HMAC_CTX ctx;
-    HMAC_CTX_init(&ctx);
+    HMAC_CTX *ctx = HMAC_CTX_new();
 
-    if (!HMAC_Init_ex(&ctx, &key_m[0], 32, EVP_sha256(), NULL)
-        || !HMAC_Update(&ctx, (uint8_t*) &psmsg->timestamp, sizeof(psmsg->timestamp))
-        || !HMAC_Update(&ctx, pPayload, nPayload)
-        || !HMAC_Final(&ctx, MAC, &nBytes)
+    if (!HMAC_Init_ex(ctx, &key_m[0], 32, EVP_sha256(), NULL)
+        || !HMAC_Update(ctx, (uint8_t*) &psmsg->timestamp, sizeof(psmsg->timestamp))
+        || !HMAC_Update(ctx, pPayload, nPayload)
+        || !HMAC_Final(ctx, MAC, &nBytes)
         || nBytes != 32)
         fHmacOk = false;
 
-    HMAC_CTX_cleanup(&ctx);
+    HMAC_CTX_free(ctx);
 
     if (!fHmacOk)
     {


### PR DESCRIPTION
## Changes

OpenSSL 1.1 has introduced some API-breaking changes: https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes#Backward_compatibility

1.
The major change is that direct stack allocation is now forbidden. For example, we cannot declare a variale like this anymore:
BN_CTX ctx;

Instead, we have to use pointers:
BN_CTX *ctx;
ctx = BN_CTX_new();
[...]
BN_CTX_free(ctx);

This impacts IC especially for the CBigNum class, but also for some other classes (EVP_CIPHER_CTX and HMAC_CTX).


2.
Some structures have become opaque, meaning that properties cannot be accessed directly any longer.
For the ECDSA_SIG structure used in IC, we have to use the ECDSA_SIG_get0 and ECDSA_SIG_set0 functions to access the 2 bignums in the structure.


3.
Some functions have been renamed:
- ECDH_set_method => EC_KEY_set_method
- ECDH_OpenSSL =>EC_KEY_OpenSSL


I have found an example of changes for the CBigNum class here: https://github.com/bitshares/bitshares-fc/commit/fee06a4c75d3215f9b502f8145383005bdda2c80


## Backward compatibility

Changes done for point 1 are backward compatible.
For points 2 and 3, I have used macros (i.e. #if OPENSSL_VERSION_NUMBER >= 0x10100000L) to ensure that IC compiles with both OpenSSL 1.0 and 1.1


## Risks

The potential risks linked to these changes:
- Crash
- Wrong results for encryption/decryption
- Memory leaks

About memory leaks:
- I have checked all changes linked to point 1, a call to the free method is always present
- I have made a small test code for the ECDSA_SIG structure and have noticed that a free was missing for OpenSSL 1.0. Now, it should be OK as the ECDSA_SIG_set0 and ECDSA_SIG_free functions both clear the 2 bignums.

As such, I do not think my changes have created new memory leaks.


## Tests done

The following functions have been tested and are working on OpenSSL 1.1:
- Creation of a new wallet and address
- RPC mining
- Receiving funds
- Sending funds

The following functions have been tested and are working on OpenSSL 1.0:
- RPC mining
- Receiving funds
- Sending funds


## Things left to do

1. Test the whole app again and again to make sure everything is working as good as before :)
2. BN_is_prime is deprecated, I will check if there is a need to replace it or not
