### PR TITLE
Add stakethreshold to getstakinginfo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 v1.1.0.1
 --------
 Added CircleCI configuration
+Added stakethreshold to getstakinginfo
 
 v1.1.0.0
 --------

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -154,7 +154,7 @@ Value getstakinginfo(const Array& params, bool fHelp)
 
     obj.push_back(Pair("expectedtime", nExpectedTime));
 
-    obj.push_back(Pair("stakethreshold", GetArg("-stakethreshold", 100)));
+    obj.push_back(Pair("stakethreshold", GetStakeCombineThreshold() / COIN));
     
     return obj;
 }

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -154,6 +154,8 @@ Value getstakinginfo(const Array& params, bool fHelp)
 
     obj.push_back(Pair("expectedtime", nExpectedTime));
 
+    obj.push_back(Pair("stakethreshold", GetArg("-stakethreshold", 100)));
+    
     return obj;
 }
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -33,7 +33,7 @@ int64_t nTransactionFee = MIN_TX_FEE;
 int64_t nReserveBalance = 0;
 int64_t nMinimumInputValue = 0;
 
-static int64_t GetStakeCombineThreshold() { return GetArg("-stakethreshold", 100) * COIN; }
+int64_t GetStakeCombineThreshold() { return GetArg("-stakethreshold", 100) * COIN; }
 static int64_t GetStakeSplitThreshold() { return 2 * GetStakeCombineThreshold(); }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -38,6 +38,8 @@ class CWalletDB;
 typedef std::map<CKeyID, CStealthKeyMetadata> StealthKeyMetaMap;
 typedef std::map<std::string, std::string> mapValue_t;
 
+extern int64_t GetStakeCombineThreshold();
+
 /** (client) version numbers for particular wallet features */
 enum WalletFeature
 {


### PR DESCRIPTION
It's relevant to staking info

Result:
```
{
    "enabled" : true,
    "staking" : false,
    "errors" : "",
    "currentblocksize" : 0,
    "currentblocktx" : 0,
    "pooledtx" : 0,
    "difficulty" : 62680.99474606,
    "search-interval" : 0,
    "weight" : 0,
    "netstakeweight" : 11014428344888,
    "expectedtime" : 0,
    "stakethreshold" : 500
}
```