### PR TITLE
Pool crash fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Ignition Release Tree
+Ignition Release Tree [![GitHub version](https://img.shields.io/badge/Version-1.1.0.0-brightgreen.svg)](https://github.com/ignitioncoin/ignitioncoin)
 
 Ignition is a PoW (NeoScrypt) / PoS / Master Node hybrid cryptocurrency, with a 5 million coin maximum supply, which is generated at a slower rate every 1 Million IC, until it's limit is reached. Master Node cost 3000IC, block size is 20MB, and block time is ~2Minutes.
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2728,16 +2728,16 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, bool fCheckSig) c
     if (vtx.empty() || vtx.size() > MAX_BLOCK_SIZE || ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
         return DoS(100, error("CheckBlock() : size limits failed"));
 
-    // Check proof of work matches claimed amount
-    if (fCheckPOW && IsProofOfWork() && !CheckProofOfWork(GetPoWHash(), nBits))
-        return DoS(50, error("CheckBlock() : proof of work failed"));
-
     // First transaction must be coinbase, the rest must not be
     if (vtx.empty() || !vtx[0].IsCoinBase())
         return DoS(100, error("CheckBlock() : first tx is not coinbase"));
     for (unsigned int i = 1; i < vtx.size(); i++)
         if (vtx[i].IsCoinBase())
             return DoS(100, error("CheckBlock() : more than one coinbase"));
+
+    // Check proof of work matches claimed amount
+    if (fCheckPOW && IsProofOfWork() && !CheckProofOfWork(GetPoWHash(), nBits))
+        return DoS(50, error("CheckBlock() : proof of work failed"));
 
     if (IsProofOfStake())
     {


### PR DESCRIPTION
Inverted PoW and coinbase check to avoid a crash if the first tx is not the coinbase