### PR TITLE
Print a success message after build

### DIFF
--- a/src/makefile.bsd
+++ b/src/makefile.bsd
@@ -113,6 +113,7 @@ ifeq (${USE_WALLET}, 1)
 endif
 
 all: Ignitiond
+	@echo "\nBuild successful!"
 
 LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -133,6 +133,7 @@ ifeq (${USE_WALLET}, 1)
 endif
 
 all: Ignitiond.exe
+	@echo "\nBuild successful!"
 
 LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
 DEFS += -I"$(CURDIR)/leveldb/include"

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -131,6 +131,7 @@ ifeq (${USE_WALLET}, 1)
 endif
 
 all: Ignitiond.exe
+	@echo "\nBuild successful!"
 
 LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a -l shlwapi
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -158,6 +158,7 @@ ifeq (${USE_LOWMEM}, 1)
 endif
 
 all: Ignitiond
+	@echo "\nBuild successful!"
 
 # build secp256k1
 DEFS += $(addprefix -I,$(CURDIR)/secp256k1/include)

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -142,6 +142,7 @@ endif
 BIN = ../bin
 
 all: ignitiond
+	@echo "\nBuild successful! The ignitiond binary can be found in the \"bin\" folder."
 
 # build secp256k1
 DEFS += $(addprefix -I,$(CURDIR)/secp256k1/include)


### PR DESCRIPTION
When the daemon is successfully built, print a message after the build.

Only tested on Linux, to be tested on Mac and Raspberry Pi.