### PR TITLE
Add vout in the listtransactions RPC command

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -8,11 +8,11 @@
 // These need to be macros, as version.cpp's and bitcoin-qt.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR       1
 #define CLIENT_VERSION_MINOR       1
-#define CLIENT_VERSION_REVISION    0
+#define CLIENT_VERSION_REVISION    1
 #define CLIENT_VERSION_BUILD       0
 
 // Set to true for release, false for prerelease or test build
-#define CLIENT_VERSION_IS_RELEASE  true
+#define CLIENT_VERSION_IS_RELEASE  false
 
 // Converts the parameter X to a string after macro replacement on X has been performed.
 // Don't merge these into one macro!

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -31,7 +31,7 @@ const std::string CLIENT_NAME("Ignition");
 // git will put "#define GIT_ARCHIVE 1" on the next line inside archives.
 #define GIT_ARCHIVE 1
 #ifdef GIT_ARCHIVE
-#    define GIT_COMMIT_ID "60029"
+#    define GIT_COMMIT_ID "RC2"
 #endif
 
 #define BUILD_DESC_FROM_COMMIT(maj,min,rev,build,commit) \

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -501,6 +501,11 @@ static void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
     mapValue["n"] = i64tostr(nOrderPos);
 }
 
+struct COutputEntry {
+    CTxDestination destination;
+    CAmount amount;
+    int vout;
+};
 
 /** A transaction with a bunch of additional info that only the owner cares about.
  * It includes any unrecorded transactions needed to link it back to the block chain.
@@ -1020,8 +1025,11 @@ public:
         return nChangeCached;
     }
 
-    void GetAmounts(std::list<std::pair<CTxDestination, int64_t> >& listReceived,
-                    std::list<std::pair<CTxDestination, int64_t> >& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter) const;
+    void GetAmounts(std::list<COutputEntry>& listReceived,
+        std::list<COutputEntry>& listSent,
+        CAmount& nFee,
+        std::string& strSentAccount,
+        const isminefilter& filter) const;
 
     void GetAccountAmounts(const std::string& strAccount, CAmount& nReceived,
                            CAmount& nSent, CAmount& nFee, const isminefilter& filter) const;


### PR DESCRIPTION
Create a new COutputEntry structure to pass the data corresponding to an entry: destination address, amount and vout index.
Use this structure in the GetAmounts function and all the functions using GetAmounts.

Fix backported from PIVX / DeviantCoin.

