### PR TITLE
Updates to makefile.osx and the build-osx.txt file for better compatibility

### DIFF
--- a/doc/build-osx.txt
+++ b/doc/build-osx.txt
@@ -13,8 +13,7 @@ MacOS Ignitiond BUILD NOTES
 
 **Tested on MacOS Mojave 10.14.2 - Darwin Kernel Version 17.3.0.  PPC is not supported because it's big-endian.**
 
-All of the commands should be executed in Terminal.app.. it's in
-/Applications/Utilities
+All of the commands should be executed in Terminal.app (located in /Applications/Utilities)
 
 You need to install XCode with all the options checked so that the compiler and everything is available in /usr not just /Developer I think it comes on the DVD but you can get the current version from http://developer.apple.com
 
@@ -30,33 +29,12 @@ git clone https://github.com/ignitioncoin/ignitioncoin
 
     `brew install qt autoconf automake libtool boost@1.59 berkeley-db@4 openssl miniupnpc gmp`
 
-5. In a separate terminal window type in `ls -td -- /usr/local/Cellar/openssl/* | head -n 1` and copy the
-version number after /usr/local/Cellar/openssl/ (in this example we'll use /usr/local/Cellar/openssl/**1.0.2q**)
-
-6. Open up `src/makefile.osx` and under `INCLUDEPATHS` AND `LIBPATHS` replace the openssl version 
-with the one copied in **Step 5** (`1.0.2q`). The lines should now read:
-    ```
-    INCLUDEPATHS= \
-    -I"$(CURDIR)" \
-    ... \
-    ... \
-    ... \
-    ... \
-    I"$(DEPSDIR)/Cellar/openssl/1.0.2q/include"
-    ```
-    ```
-    LIBPATHS= \
-     ... \
-     ... \
-     ... \
-     -L"$(DEPSDIR)/Cellar/openssl/1.0.2q/lib"
-    ```
-
-7.  Now you should be able to build Ignitiond:
+5.  Now you should be able to build Ignitiond:
     ```
     cd Ignition/src
     make -f makefile.osx
     ```
+
 #### Other Ignitiond commands
     Run:
       `./Ignitiond --help  # for a list of command-line options.`

--- a/doc/build-osx.txt
+++ b/doc/build-osx.txt
@@ -9,20 +9,14 @@ Thomas Bernard.
 
 MacOS Ignitiond BUILD NOTES
 ===========================
+**See readme-qt.rst for instructions on building Ignition QT, the graphical user interface.**
 
-
-See readme-qt.rst for instructions on building Ignition QT, the
-graphical user interface.
-
-Tested on MacOS High Sierra 10.13.2 - Darwin Kernel Version 17.3.0.  PPC is not supported because it's big-endian.
+**Tested on MacOS Mojave 10.14.2 - Darwin Kernel Version 17.3.0.  PPC is not supported because it's big-endian.**
 
 All of the commands should be executed in Terminal.app.. it's in
 /Applications/Utilities
 
-You need to install XCode with all the options checked so that the compiler and
-everything is available in /usr not just /Developer I think it comes on the DVD
-but you can get the current version from http://developer.apple.com
-
+You need to install XCode with all the options checked so that the compiler and everything is available in /usr not just /Developer I think it comes on the DVD but you can get the current version from http://developer.apple.com
 
 1.  Clone the github tree to get the source code:
 
@@ -30,23 +24,33 @@ git clone https://github.com/ignitioncoin/ignitioncoin
 
 2.  Install XCode and it's command line tools
 
-3.  Download and install Homebrew from https://brew.sh/
+3.  Download and install Homebrew using instructions from https://brew.sh/
 
 4.  Install dependencies from Homebrew
 
-brew install qt autoconf automake libtool boost@1.59 berkeley-db@4 openssl miniupnpc gmp
+    `brew install qt autoconf automake libtool boost@1.59 berkeley-db@4 openssl miniupnpc gmp`
 
-Optionally install qrencode (and set USE_QRCODE=1):
-brew install qrencode
+* Optionally install qrencode 
+(and use USE_QRCODE=1 when building the binary. Example: `make -f makefile.osx USE_QRCODE=1`):
 
-4.  Now you should be able to build Ignitiond:
+    `brew install qrencode`
 
-cd Ignition/src
-make -f makefile.osx
+5. In a separate terminal window type in `ls -td -- /usr/local/Cellar/openssl/* | head -n 1` and copy the
+version number after /usr/local/Cellar/openssl/ (in this example we'll use /usr/local/Cellar/openssl/**1.0.2q**)
 
-Run:
-  ./Ignitiond --help  # for a list of command-line options.
-Run
-  ./Ignitiond -daemon # to start the Ignition daemon.
-Run
-  ./Ignitiond help # When the daemon is running, to get a list of RPC commands
+6. Open up `src/makefile.osx` and under `INCLUDEPATHS` replace the openssl version 
+with the one copied in **Step 5** (`1.0.2q`). The line should now read:
+`-I"$(DEPSDIR)/Cellar/openssl/1.0.2q/include"`
+
+7.  Now you should be able to build Ignitiond:
+    ```
+    cd Ignition/src
+    make -f makefile.osx
+    ```
+#### Other Ignitiond commands
+    Run:
+      `./Ignitiond --help  # for a list of command-line options.`
+    Run
+      `./Ignitiond -daemon # to start the Ignition daemon.`
+    Run
+      `./Ignitiond help # When the daemon is running, to get a list of RPC commands`

--- a/doc/build-osx.txt
+++ b/doc/build-osx.txt
@@ -19,7 +19,7 @@ All of the commands should be executed in Terminal.app (located in /Applications
 You need to install XCode with all the options checked so that the compiler and everything is available in /usr not just /Developer. You can get the current version from http://developer.apple.com or by running `xcode-select --install` in terminal
 
 1.  Clone the github tree to get the source code:
-    `git clone https://github.com/ignitioncoin/ignitioncoin`
+    `git clone https://github.com/ignitioncoin/ignitioncoin Ignition`
 
 2.  Install XCode and it's command line tools (for Homebrew and other compiling functions)
     `xcode-select --install`

--- a/doc/build-osx.txt
+++ b/doc/build-osx.txt
@@ -33,9 +33,24 @@ git clone https://github.com/ignitioncoin/ignitioncoin
 5. In a separate terminal window type in `ls -td -- /usr/local/Cellar/openssl/* | head -n 1` and copy the
 version number after /usr/local/Cellar/openssl/ (in this example we'll use /usr/local/Cellar/openssl/**1.0.2q**)
 
-6. Open up `src/makefile.osx` and under `INCLUDEPATHS` replace the openssl version 
-with the one copied in **Step 5** (`1.0.2q`). The line should now read:
-`-I"$(DEPSDIR)/Cellar/openssl/1.0.2q/include"`
+6. Open up `src/makefile.osx` and under `INCLUDEPATHS` AND `LIBPATHS` replace the openssl version 
+with the one copied in **Step 5** (`1.0.2q`). The lines should now read:
+    ```
+    INCLUDEPATHS= \
+    -I"$(CURDIR)" \
+    ... \
+    ... \
+    ... \
+    ... \
+    I"$(DEPSDIR)/Cellar/openssl/1.0.2q/include"
+    ```
+    ```
+    LIBPATHS= \
+     ... \
+     ... \
+     ... \
+     -L"$(DEPSDIR)/Cellar/openssl/1.0.2q/lib"
+    ```
 
 7.  Now you should be able to build Ignitiond:
     ```

--- a/doc/build-osx.txt
+++ b/doc/build-osx.txt
@@ -30,11 +30,6 @@ git clone https://github.com/ignitioncoin/ignitioncoin
 
     `brew install qt autoconf automake libtool boost@1.59 berkeley-db@4 openssl miniupnpc gmp`
 
-* Optionally install qrencode 
-(and use USE_QRCODE=1 when building the binary. Example: `make -f makefile.osx USE_QRCODE=1`):
-
-    `brew install qrencode`
-
 5. In a separate terminal window type in `ls -td -- /usr/local/Cellar/openssl/* | head -n 1` and copy the
 version number after /usr/local/Cellar/openssl/ (in this example we'll use /usr/local/Cellar/openssl/**1.0.2q**)
 

--- a/doc/build-osx.txt
+++ b/doc/build-osx.txt
@@ -6,6 +6,7 @@ OpenSSL Toolkit (http://www.openssl.org/).  This product includes cryptographic
 software written by Eric Young (eay@cryptsoft.com) and UPnP software written by
 Thomas Bernard.
 
+2017 - 2019 : Modifications by Ignition Coin
 
 MacOS Ignitiond BUILD NOTES
 ===========================
@@ -15,13 +16,13 @@ MacOS Ignitiond BUILD NOTES
 
 All of the commands should be executed in Terminal.app (located in /Applications/Utilities)
 
-You need to install XCode with all the options checked so that the compiler and everything is available in /usr not just /Developer I think it comes on the DVD but you can get the current version from http://developer.apple.com
+You need to install XCode with all the options checked so that the compiler and everything is available in /usr not just /Developer. You can get the current version from http://developer.apple.com or by running `xcode-select --install` in terminal
 
 1.  Clone the github tree to get the source code:
+    `git clone https://github.com/ignitioncoin/ignitioncoin`
 
-git clone https://github.com/ignitioncoin/ignitioncoin
-
-2.  Install XCode and it's command line tools
+2.  Install XCode and it's command line tools (for Homebrew and other compiling functions)
+    `xcode-select --install`
 
 3.  Download and install Homebrew using instructions from https://brew.sh/
 

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -10,13 +10,17 @@ CXX=clang++
 C=clang
 DEPSDIR=/usr/local
 
+# For the OpenSSL include path, please make sure you're using the 
+# correct version for your machine as this dependency is constantly
+# being updated and there is no common folder for the OpenSSL dependencies
+
 INCLUDEPATHS= \
  -I"$(CURDIR)" \
  -I"$(CURDIR)"/obj \
  -I"$(DEPSDIR)/include" \
  -I"$(DEPSDIR)/Cellar/boost@1.59/1.59.0/include" \
  -I"$(DEPSDIR)/Cellar/berkeley-db@4/4.8.30/include" \
- -I"$(DEPSDIR)/Cellar/openssl/1.0.2n/include"
+ -I"$(DEPSDIR)/Cellar/openssl/1.0.2q/include"
 
 LIBPATHS= \
  -L"$(DEPSDIR)/lib" \
@@ -61,13 +65,13 @@ ifdef RELEASE
 # Compile for maximum compatibility and smallest size.
 # This requires that dependencies are compiled
 # the same way.
-CFLAGS = -mmacosx-version-min=10.8 -arch x86_64 -O3
+CFLAGS = -std=gnu++11 -mmacosx-version-min=10.8 -arch x86_64 -O3
 else
 DEBUGFLAGS = -g
 endif
 
 # ppc doesn't work because we don't support big-endian
-CFLAGS += -Wall -Wextra -Wformat -Wno-ignored-qualifiers -Wformat-security -Wno-unused-parameter -Wunused-function -Wunused-variable -fpermissive -Wconversion-null -Wno-deprecated-declarations\
+CFLAGS += -std=gnu++11 -Wall -Wextra -Wformat -Wno-ignored-qualifiers -Wformat-security -Wno-unused-parameter -Wunused-function -Wunused-variable -fpermissive -Wconversion-null -Wno-deprecated-declarations\
     $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 
 OBJS= \

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -26,7 +26,7 @@ LIBPATHS= \
  -L"$(DEPSDIR)/lib" \
  -L"$(DEPSDIR)/Cellar/boost@1.59/1.59.0/lib" \
  -L"$(DEPSDIR)/Cellar/berkeley-db@4/4.8.30/lib" \
- -L"$(DEPSDIR)/Cellar/openssl/1.0.2n/lib"
+ -L"$(DEPSDIR)/Cellar/openssl/1.0.2q/lib"
 
 USE_UPNP:=1
 USE_WALLET:=1
@@ -197,7 +197,7 @@ obj/%.o: %.c
 	  rm -f $(@:%.o=%.d)
 
 obj/neoscrypt.o: neoscrypt.c
-	$(CC) $(CFLAGS) -DSHA256 -DASM -DOPT -c -o $@ $^
+	$(CC) $(printf '%s' "$(CFLAGS)" | sed 's/-std=gnu++11//g') -DSHA256 -DASM -DOPT -c -o $@ $^
 
 obj/neoscrypt_asm.o: neoscrypt_asm.S
 	$(CC) -c -DSHA256 -DASM -DOPT -DMOVQ_FIX -o $@ $^

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -9,6 +9,10 @@
 CXX=clang++
 C=clang
 DEPSDIR=/usr/local
+DEPSDIRSLASHED=$(shell echo ${DEPSDIR} | sed 's/\//\\\//g')
+
+# Grab OpenSSL folder name dynamically 
+OPENSSLVERSION=$(shell ls -td -- $(DEPSDIR)/Cellar/openssl/* | head -n 1 | sed 's/${DEPSDIRSLASHED}\/Cellar\/openssl\///g')
 
 # For the OpenSSL include path, please make sure you're using the 
 # correct version for your machine as this dependency is constantly
@@ -20,13 +24,13 @@ INCLUDEPATHS= \
  -I"$(DEPSDIR)/include" \
  -I"$(DEPSDIR)/Cellar/boost@1.59/1.59.0/include" \
  -I"$(DEPSDIR)/Cellar/berkeley-db@4/4.8.30/include" \
- -I"$(DEPSDIR)/Cellar/openssl/1.0.2q/include"
+ -I"$(DEPSDIR)/Cellar/openssl/$(OPENSSLVERSION)/include"
 
 LIBPATHS= \
  -L"$(DEPSDIR)/lib" \
  -L"$(DEPSDIR)/Cellar/boost@1.59/1.59.0/lib" \
  -L"$(DEPSDIR)/Cellar/berkeley-db@4/4.8.30/lib" \
- -L"$(DEPSDIR)/Cellar/openssl/1.0.2q/lib"
+ -L"$(DEPSDIR)/Cellar/openssl/$(OPENSSLVERSION)/lib"
 
 USE_UPNP:=1
 USE_WALLET:=1


### PR DESCRIPTION
On Mojave and High Sierra, the -std=gnu++11 flag is needed to build some of the C++ modules. This branch fixes that issue and also brings some features to the Mac build process (auto find correct openssl version folder).

To test, please follow instructions in docs/build-osx.txt to build Ignitiond